### PR TITLE
smartos-ui#4 exit_status needs to be i64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,7 +1779,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smartos_shared"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "dropshot",
  "http 0.2.12",
@@ -1795,7 +1795,7 @@ dependencies = [
 
 [[package]]
 name = "smartos_ui"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "askama",
  "build-data",
@@ -1820,7 +1820,7 @@ dependencies = [
 
 [[package]]
 name = "smartos_ui_executor"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "dropshot",
  "http 0.2.12",

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smartos_ui_executor"
-version = "0.1.19"
+version = "0.1.20"
 homepage = "https://github.com/tritondatacenter/smartos-ui"
 description = "SmartOS UI Executor"
 edition = "2021"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smartos_shared"
-version = "0.1.19"
+version = "0.1.20"
 homepage = "https://github.com/tritondatacenter/smartos-ui"
 description = "SmartOS UI shared structs and functions"
 edition = "2021"

--- a/shared/src/instance.rs
+++ b/shared/src/instance.rs
@@ -98,7 +98,7 @@ pub struct Generic {
     pub zoneid: Option<u64>,
 
     // if stopped
-    pub exit_status: Option<u64>,
+    pub exit_status: Option<i64>,
     pub exit_timestamp: Option<String>,
 }
 

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smartos_ui"
-version = "0.1.19"
+version = "0.1.20"
 homepage = "https://github.com/tritondatacenter/smartos-ui"
 description = "SmartOS UI"
 edition = "2021"


### PR DESCRIPTION
In #4, ultimately we boiled down to having `exit_status` returned by vmadm being `-134`, and that's the cause of the UI crash.

Because `vmadm` is capable of returning negative values here, it was a bug for the rust data type here to be unsigned, and must be signed instead.