### PR TITLE
smartos-ui#9 build_stamp definition should pass cargo check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,7 +1779,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smartos_shared"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "dropshot",
  "http 0.2.12",
@@ -1795,7 +1795,7 @@ dependencies = [
 
 [[package]]
 name = "smartos_ui"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "askama",
  "build-data",
@@ -1820,7 +1820,7 @@ dependencies = [
 
 [[package]]
 name = "smartos_ui_executor"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "dropshot",
  "http 0.2.12",

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smartos_ui_executor"
-version = "0.1.20"
+version = "0.1.21"
 homepage = "https://github.com/tritondatacenter/smartos-ui"
 description = "SmartOS UI Executor"
 edition = "2021"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smartos_shared"
-version = "0.1.20"
+version = "0.1.21"
 homepage = "https://github.com/tritondatacenter/smartos-ui"
 description = "SmartOS UI shared structs and functions"
 edition = "2021"

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smartos_ui"
-version = "0.1.20"
+version = "0.1.21"
 homepage = "https://github.com/tritondatacenter/smartos-ui"
 description = "SmartOS UI"
 edition = "2021"

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -36,8 +36,7 @@ async fn main() -> Result<(), String> {
     // binary, but this runs afoul of things like `cargo check`. By making it
     // optional, and inserting a well-known fake stamp if it's missing, we
     // can successfully get through `cargo check`
-    let build_stamp_r = option_env!("STAMP");
-    let build_stamp = build_stamp_r.unwrap_or("00000000T000000Z");
+    let build_stamp = option_env!("STAMP").unwrap_or("00000000T000000Z");
 
     // If provided with a single argument of "version", print version and exit.
     let mut args = env::args();

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -31,7 +31,17 @@ use tokio::try_join;
 async fn main() -> Result<(), String> {
     let name = option_env!("CARGO_PKG_NAME").unwrap_or("?");
     let full_version = format!("{}-{}", VERSION, GIT_COMMIT_SHORT);
-    let build_stamp = env!("STAMP", "STAMP not defined.");
+
+    // We want the build stamp provided by the Makefile inserted into the
+    // binary, but this runs afoul of things like `cargo check`. By making it
+    // optional, and inserting a well-known fake stamp if it's missing, we
+    // can successfully get through `cargo check`
+    let build_stamp_r = option_env!("STAMP");
+    let build_stamp;
+    match build_stamp_r {
+        Some(x) => build_stamp = x,
+        None => build_stamp = "00000000T000000Z",
+    }
 
     // If provided with a single argument of "version", print version and exit.
     let mut args = env::args();

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -37,10 +37,7 @@ async fn main() -> Result<(), String> {
     // optional, and inserting a well-known fake stamp if it's missing, we
     // can successfully get through `cargo check`
     let build_stamp_r = option_env!("STAMP");
-    let build_stamp = match build_stamp_r {
-        Some(x) => x,
-        None => "00000000T000000Z",
-    };
+    let build_stamp = build_stamp_r.unwrap_or("00000000T000000Z");
 
     // If provided with a single argument of "version", print version and exit.
     let mut args = env::args();

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -37,11 +37,10 @@ async fn main() -> Result<(), String> {
     // optional, and inserting a well-known fake stamp if it's missing, we
     // can successfully get through `cargo check`
     let build_stamp_r = option_env!("STAMP");
-    let build_stamp;
-    match build_stamp_r {
-        Some(x) => build_stamp = x,
-        None => build_stamp = "00000000T000000Z",
-    }
+    let build_stamp = match build_stamp_r {
+        Some(x) => x,
+        None => "00000000T000000Z",
+    };
 
     // If provided with a single argument of "version", print version and exit.
     let mut args = env::args();


### PR DESCRIPTION
This was bugging me for a bit, and I figured out how to fix it today. Fixes #9.